### PR TITLE
Add torch installation

### DIFF
--- a/cmd_gen_finetuning.ipynb
+++ b/cmd_gen_finetuning.ipynb
@@ -44,6 +44,7 @@
    "source": [
     "%%sh\n",
     "# install unsloth and other dependencies\n",
+    "pip install torch==2.2.2\n",
     "pip install \"unsloth[colab-new] @ git+https://github.com/unslothai/unsloth.git\"\n",
     "pip install --no-deps \"xformers<=0.0.26\" \"trl<0.9.0\" peft accelerate bitsandbytes huggingface_hub[cli]\n",
     "# remove tpu-only package that is installed by default on gcp runtimes, even when only using gpu\n",


### PR DESCRIPTION
Add installation for specific package of torch. This ensures that the environment has CUDA 12.1 installed so that packages like xformers don't error out.